### PR TITLE
Abstract interface and method implementations must mach

### DIFF
--- a/src/module_time_integration.f90
+++ b/src/module_time_integration.f90
@@ -29,7 +29,7 @@ module time_integrator
      subroutine integrate_proc(self, afield)
        import time_integrator_type, field_type
        class(time_integrator_type), intent(in) :: self
-       class(field_type), intent(inout) :: afield
+       class(field_type), allocatable, intent(inout) :: afield
      end subroutine integrate_proc
   end interface
 


### PR DESCRIPTION
Abstract interface of integrate was missing allocatable on the field object.

Chose to make the field allocatable in the interface as this was used in all implementations, if inverse is intended will update pull request.